### PR TITLE
Fix time range being incorrectly reported to start at 0

### DIFF
--- a/src/ULog.test.ts
+++ b/src/ULog.test.ts
@@ -301,7 +301,7 @@ describe("README.md", () => {
     const ulog = new ULog(reader);
     await ulog.open(); // required before any other operations
     expect(ulog.messageCount()).toBe(64599); // ex: 64599
-    expect(ulog.timeRange()).toEqual([112574307n, 181493506n]);
+    expect(ulog.timeRange()).toEqual([0n, 181493506n]); // ex: [ 0n, 181493506n ]
 
     const msgIdCounts = new Map<number, number>();
     for await (const msg of ulog.readMessages()) {

--- a/src/ULog.test.ts
+++ b/src/ULog.test.ts
@@ -301,7 +301,7 @@ describe("README.md", () => {
     const ulog = new ULog(reader);
     await ulog.open(); // required before any other operations
     expect(ulog.messageCount()).toBe(64599); // ex: 64599
-    expect(ulog.timeRange()).toEqual([0n, 181493506n]); // ex: [ 0n, 181493506n ]
+    expect(ulog.timeRange()).toEqual([112574307n, 181493506n]);
 
     const msgIdCounts = new Map<number, number>();
     for await (const msg of ulog.readMessages()) {

--- a/src/ULog.ts
+++ b/src/ULog.ts
@@ -250,7 +250,7 @@ export class ULog {
     this._timeIndex = timeIndex.sort(sortTimeIndex);
     this._dataMessageCounts = dataCounts;
     this._logMessageCount = logMessageCount;
-    this._dataTimeRange = minTimestamp ? [minTimestamp, maxTimestamp] : undefined;
+    this._dataTimeRange = minTimestamp != undefined ? [minTimestamp, maxTimestamp] : undefined;
   }
 
   private async readParsedMessage(): Promise<DataSectionMessage | undefined> {

--- a/src/ULog.ts
+++ b/src/ULog.ts
@@ -229,14 +229,18 @@ export class ULog {
     let message: DataSectionMessage | undefined;
     while ((message = await this.readParsedMessage())) {
       if (message.type === MessageType.Data) {
-        minTimestamp ??= message.value.timestamp;
+        if (minTimestamp == undefined || message.value.timestamp < minTimestamp) {
+          minTimestamp = message.value.timestamp;
+        }
         if (message.value.timestamp > maxTimestamp) {
           maxTimestamp = message.value.timestamp;
         }
         timeIndex.push([message.value.timestamp, i++, message]);
         dataCounts.set(message.msgId, (dataCounts.get(message.msgId) ?? 0) + 1);
       } else if (message.type === MessageType.Log || message.type === MessageType.LogTagged) {
-        minTimestamp ??= message.timestamp;
+        if (minTimestamp == undefined || message.timestamp < minTimestamp) {
+          minTimestamp = message.timestamp;
+        }
         if (message.timestamp > maxTimestamp) {
           maxTimestamp = message.timestamp;
         }

--- a/src/ULog.ts
+++ b/src/ULog.ts
@@ -223,28 +223,35 @@ export class ULog {
   }
 
   private async createIndex(): Promise<void> {
+    if (!this._header) {
+      throw new Error("Cannot createIndex before reading header");
+    }
+
     const timeIndex: IndexEntry[] = [];
     const dataCounts = new Map<number, number>();
-    let maxTimestamp = 0n;
+    let maxTimestamp: bigint | undefined;
     let logMessageCount = 0;
 
     let i = 0;
     let message: DataSectionMessage | undefined;
     while ((message = await this.readParsedMessage())) {
       if (message.type === MessageType.Data) {
-        if (message.value.timestamp > maxTimestamp) {
+        if (maxTimestamp == undefined || message.value.timestamp > maxTimestamp) {
           maxTimestamp = message.value.timestamp;
         }
         timeIndex.push([message.value.timestamp, i++, message]);
         dataCounts.set(message.msgId, (dataCounts.get(message.msgId) ?? 0) + 1);
       } else if (message.type === MessageType.Log || message.type === MessageType.LogTagged) {
-        if (message.timestamp > maxTimestamp) {
+        if (maxTimestamp == undefined || message.timestamp > maxTimestamp) {
           maxTimestamp = message.timestamp;
         }
         timeIndex.push([message.timestamp, i++, message]);
         logMessageCount++;
       } else {
-        timeIndex.push([maxTimestamp, i++, message]);
+        // Other message types do not have a timestamp field, so we use the current max. timestamp or
+        // alternatively the header timestamp which denotes when the logging started.
+        const timestamp = maxTimestamp ?? this._header.timestamp;
+        timeIndex.push([timestamp, i++, message]);
       }
     }
 


### PR DESCRIPTION
### Changelog
Fix time range being incorrectly reported to start at 0

### Docs
None

### Description
Fixes that the time range being incorrectly reported to start at 0 by using only data & log messages for determining the time range.
