### PR TITLE
fix outdated CI node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           lfs: true
+      - run: corepack enable
       - uses: actions/setup-node@v4.1.0
         with:
           node-version: 20
           cache: yarn
 
-      - run: corepack enable
       - run: yarn install --frozen-lockfile
       - run: yarn run build
       - run: yarn run lint:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
         with:
           lfs: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4.1.0
         with:
-          node-version: 16.x
-          registry-url: https://registry.npmjs.org
+          node-version: 20
+          cache: yarn
 
       - run: corepack enable
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     name: push
     runs-on: ubuntu-latest
 
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -19,16 +23,18 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4.1.0
         with:
-          node-version: 20
+          node-version: 22.x
           cache: yarn
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --immutable
       - run: yarn run build
       - run: yarn run lint:ci
       - run: yarn run test
 
+      - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish package.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,10 @@ dist
 # MacOS
 .DS_Store
 
-# Yarn
+# Yarn & packaging
+.pnp.*
 .yarn
+!.yarn/patches
+!.yarn/plugins
+!.yarn/sdks
+*.tgz


### PR DESCRIPTION
### Changelog
fix outdated CI node version

### Docs
None

### Description
https://github.com/foxglove/ulog/pull/7 updated the package manager which requires a newer node version.

CI on that PR passed (https://github.com/foxglove/ulog/actions/runs/11918005719/job/33214424897), even though yarn errors are logged :confused: 
