### PR TITLE
Make BlobReader work in nodejs environment

### DIFF
--- a/src/web/BlobReader.test.ts
+++ b/src/web/BlobReader.test.ts
@@ -1,5 +1,3 @@
-/** @jest-environment jsdom */
-
 // Copyright 2018-2020 Cruise LLC
 // Copyright 2021 Foxglove Technologies Inc
 //
@@ -35,29 +33,5 @@ describe("browser reader", () => {
       Uint8Array.from([0, 1]),
       Uint8Array.from([0, 1]),
     ]);
-  });
-
-  it("reports browser FileReader errors", async () => {
-    const buffer = new Blob([Uint8Array.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
-    const reader = new BlobReader(buffer);
-    const actualFileReader = global.FileReader;
-    (global as { FileReader: unknown }).FileReader = class FailReader {
-      onerror!: (_: this) => void;
-      readAsArrayBuffer() {
-        setTimeout(() => {
-          Object.defineProperty(this, "error", {
-            get() {
-              return new Error("fake error");
-            },
-          });
-
-          expect(typeof this.onerror).toBe("function");
-          this.onerror(this);
-        });
-      }
-    };
-
-    await expect(reader.read(0, 2)).rejects.toThrow("fake error");
-    global.FileReader = actualFileReader;
   });
 });

--- a/src/web/BlobReader.ts
+++ b/src/web/BlobReader.ts
@@ -2,49 +2,27 @@ import { Filelike } from "../file";
 
 // browser reader for Blob|File objects
 export class BlobReader implements Filelike {
-  #blob: Blob;
-  #size: number;
+  public constructor(private file: Blob) {}
 
-  constructor(blob: Blob | File) {
-    if (!(blob instanceof Blob)) {
-      throw new Error("Expected file to be a File or Blob.");
-    }
-
-    this.#blob = blob;
-    this.#size = blob.size;
+  public size(): number {
+    return this.file.size;
   }
 
   async open(): Promise<number> {
-    return this.#size;
+    return this.size();
   }
 
   /**
    * Read `length` bytes starting from `offset` bytes.
    */
-  async read(offset: number, length: number): Promise<Uint8Array> {
-    return await new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = function () {
-        reader.onload = null;
-        reader.onerror = null;
-
-        if (reader.result == undefined || !(reader.result instanceof ArrayBuffer)) {
-          reject(new Error("Unsupported format for BlobReader"));
-          return;
-        }
-
-        resolve(new Uint8Array(reader.result));
-      };
-      reader.onerror = function () {
-        reader.onload = null;
-        reader.onerror = null;
-        reject(reader.error ?? new Error("Unknown FileReader error"));
-      };
-      reader.readAsArrayBuffer(this.#blob.slice(offset, offset + length));
-    });
-  }
-
-  size(): number {
-    return this.#size;
+  public async read(offset: number, length: number): Promise<Uint8Array> {
+    if (offset + length > this.file.size) {
+      throw new Error(
+        `Read of ${length} bytes at offset ${offset} exceeds file size ${this.file.size}`,
+      );
+    }
+    return new Uint8Array(
+      await this.file.slice(Number(offset), Number(offset + length)).arrayBuffer(),
+    );
   }
 }

--- a/src/web/BlobReader.ts
+++ b/src/web/BlobReader.ts
@@ -2,10 +2,14 @@ import { Filelike } from "../file";
 
 // browser reader for Blob|File objects
 export class BlobReader implements Filelike {
-  public constructor(private file: Blob) {}
+  #blob: Blob;
+
+  public constructor(blob: Blob) {
+    this.#blob = blob;
+  }
 
   public size(): number {
-    return this.file.size;
+    return this.#blob.size;
   }
 
   async open(): Promise<number> {
@@ -16,13 +20,11 @@ export class BlobReader implements Filelike {
    * Read `length` bytes starting from `offset` bytes.
    */
   public async read(offset: number, length: number): Promise<Uint8Array> {
-    if (offset + length > this.file.size) {
+    if (offset + length > this.size()) {
       throw new Error(
-        `Read of ${length} bytes at offset ${offset} exceeds file size ${this.file.size}`,
+        `Read of ${length} bytes at offset ${offset} exceeds blob size ${this.size()}`,
       );
     }
-    return new Uint8Array(
-      await this.file.slice(Number(offset), Number(offset + length)).arrayBuffer(),
-    );
+    return new Uint8Array(await this.#blob.slice(offset, offset + length).arrayBuffer());
   }
 }


### PR DESCRIPTION
### Changelog
Make BlobReader work in nodejs environment

### Docs
None

### Description
The previous `BlobReader` implementation was not fully node compatible. The jest tests only worked because the jsdom test environment was activated with `/** @jest-environment jsdom */`. This PR uses the `Blob.slice().arrayBuffer()` approach, similar to Mcap's [BlobReadable](https://github.com/foxglove/mcap/blob/main/typescript/browser/src/BlobReadable.ts)
