### PR TITLE
Add util to convert ULog files to MCAP

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
   "packageManager": "yarn@4.5.1",
   "dependencies": {
     "@mcap/core": "^2.1.7",
-    "@mcap/nodejs": "^1.0.2"
+    "@mcap/nodejs": "^1.0.2",
+    "@mcap/support": "^1.0.4",
+    "protobufjs": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
     "typescript": "5.8.3",
     "typescript-eslint": "8.32.0"
   },
-  "packageManager": "yarn@4.5.1"
+  "packageManager": "yarn@4.5.1",
+  "dependencies": {
+    "@mcap/core": "^2.1.7",
+    "@mcap/nodejs": "^1.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "@mcap/core": "^2.1.7",
     "@mcap/nodejs": "^1.0.2",
     "@mcap/support": "^1.0.4",
-    "protobufjs": "^8.0.0"
+    "protobufjs": "^7.2.5"
   }
 }

--- a/src/convert.test.ts
+++ b/src/convert.test.ts
@@ -1,11 +1,16 @@
 import { McapIndexedReader, TempBuffer, McapWriter } from "@mcap/core";
+import { Metadata } from "@mcap/core/src/types";
+import { protobufFromBinaryDescriptor } from "@mcap/support";
+import Long from "long";
 
 import { ULog, Subscription } from "./ULog";
-import { ulogDefinitionToJSONSchema, convertULogFileToMCAP } from "./convert";
+import { convertULogFileToMCAP } from "./convert";
 import { MessageDefinition, Field } from "./definition";
 import { MessageType } from "./enums";
 import { ParsedMessage } from "./messages";
 import { FileReader } from "./node/FileReader";
+
+type MockMessage = ParsedMessage & { topic: string; multiId?: number };
 
 function createULogMock({
   messageFields,
@@ -14,9 +19,9 @@ function createULogMock({
   messages = [],
 }: {
   messageFields: Map<string, Field[]>;
-  subscriptions: string[];
+  subscriptions: { name: string; multiId?: number }[];
   timestamp?: bigint;
-  messages?: { topic: string; message: ParsedMessage }[];
+  messages?: MockMessage[];
 }): jest.Mocked<ULog> {
   const msgIds = new Map<string, number>();
   const definitions = new Map<string, MessageDefinition>();
@@ -28,11 +33,11 @@ function createULogMock({
     } as MessageDefinition);
   });
   const subscriptionMap = new Map<number, Subscription>();
-  subscriptions.forEach((name, index) => {
-    msgIds.set(name, index + 1);
+  subscriptions.forEach((subscription, index) => {
+    msgIds.set(`${subscription.name}/${subscription.multiId ?? 0}`, index + 1);
     subscriptionMap.set(index + 1, {
-      multiId: index + 1,
-      ...definitions.get(name)!,
+      multiId: subscription.multiId ?? 0,
+      ...definitions.get(subscription.name)!,
     });
   });
   const ulogMock: jest.Mocked<ULog> = {
@@ -40,14 +45,16 @@ function createULogMock({
     header: {
       timestamp,
       definitions,
+      version: 1,
     },
     subscriptions: subscriptionMap,
     readMessages: jest.fn().mockImplementation(async function* () {
       for (const msg of messages) {
+        const { topic, multiId, ...messageContent } = msg;
         yield {
           type: MessageType.Data,
-          msgId: msgIds.get(msg.topic)!,
-          value: msg.message,
+          msgId: msgIds.get(`${topic}/${multiId ?? 0}`)!,
+          value: messageContent,
         };
       }
     }),
@@ -56,141 +63,6 @@ function createULogMock({
 }
 
 describe("Create MCAP files from ULog", () => {
-  describe("Schema Conversion", () => {
-    it("should throw an error for missing ULog definitions", () => {
-      const definitions = new Map<string, MessageDefinition>();
-      expect(() => {
-        ulogDefinitionToJSONSchema("NonExistentSchema", definitions);
-      }).toThrow("Missing ULog definition for message type: NonExistentSchema");
-    });
-
-    it("should convert primitive field types", () => {
-      const definition = {
-        name: "TestSchema",
-        fields: [
-          { name: "uint_1", type: "uint8_t", isComplex: false },
-          { name: "uint_2", type: "uint16_t", isComplex: false },
-          { name: "uint_3", type: "uint32_t", isComplex: false },
-          { name: "uint_4", type: "uint64_t", isComplex: false },
-          { name: "int_1", type: "int8_t", isComplex: false },
-          { name: "int_2", type: "int16_t", isComplex: false },
-          { name: "int_3", type: "int32_t", isComplex: false },
-          { name: "int_4", type: "int64_t", isComplex: false },
-          { name: "float_1", type: "float", isComplex: false },
-          { name: "float_2", type: "double", isComplex: false },
-          { name: "bool", type: "bool", isComplex: false },
-          { name: "string", type: "char", isComplex: false },
-          { name: "string", type: "char", arrayLength: 4, isComplex: false },
-          { name: "string", type: "char", arrayLength: 20, isComplex: false },
-        ],
-        format: "not read",
-      };
-      const definitions = new Map<string, MessageDefinition>();
-      definitions.set("TestSchema", definition);
-      const schemaName = "TestSchema";
-      const schema = ulogDefinitionToJSONSchema(schemaName, definitions);
-      expect(schema).toEqual({
-        title: "TestSchema",
-        type: "object",
-        properties: {
-          uint_1: { type: "integer" },
-          uint_2: { type: "integer" },
-          uint_3: { type: "integer" },
-          uint_4: { type: "integer" },
-          int_1: { type: "integer" },
-          int_2: { type: "integer" },
-          int_3: { type: "integer" },
-          int_4: { type: "integer" },
-          float_1: { type: "number" },
-          float_2: { type: "number" },
-          bool: { type: "boolean" },
-          string: { type: "string" },
-        },
-      });
-    });
-
-    it("should convert array field types correctly", () => {
-      const definition = {
-        name: "ArraySchema",
-        fields: [
-          { name: "array_int", type: "uint8_t", arrayLength: 4, isComplex: false },
-          { name: "array_int16", type: "int16_t", arrayLength: 2, isComplex: false },
-          { name: "array_float", type: "float", arrayLength: 3, isComplex: false },
-          { name: "string_type", type: "char", arrayLength: 5, isComplex: false }, // Should be treated as string, not array
-        ],
-        format: "not read",
-      };
-      const definitions = new Map<string, MessageDefinition>();
-      definitions.set("ArraySchema", definition);
-      const schemaName = "ArraySchema";
-      const schema = ulogDefinitionToJSONSchema(schemaName, definitions);
-      expect(schema).toEqual({
-        title: "ArraySchema",
-        type: "object",
-        properties: {
-          array_int: {
-            type: "array",
-            items: { type: "integer" },
-            minItems: 4,
-            maxItems: 4,
-          },
-          array_int16: {
-            type: "array",
-            items: { type: "integer" },
-            minItems: 2,
-            maxItems: 2,
-          },
-          array_float: {
-            type: "array",
-            items: { type: "number" },
-            minItems: 3,
-            maxItems: 3,
-          },
-          string_type: { type: "string" },
-        },
-      });
-    });
-
-    it("should convert nested struct field types correctly", () => {
-      const nestedDefinition = {
-        name: "NestedStruct",
-        fields: [
-          { name: "nested_int", type: "int32_t", isComplex: false },
-          { name: "nested_float", type: "float", isComplex: false },
-        ],
-        format: "not read",
-      };
-      const mainDefinition = {
-        name: "MainStruct",
-        fields: [
-          { name: "main_int", type: "uint16_t", isComplex: false },
-          { name: "nested", type: "NestedStruct", isComplex: true },
-        ],
-        format: "not read",
-      };
-      const definitions = new Map<string, MessageDefinition>();
-      definitions.set("NestedStruct", nestedDefinition);
-      definitions.set("MainStruct", mainDefinition);
-      const schemaName = "MainStruct";
-      const schema = ulogDefinitionToJSONSchema(schemaName, definitions);
-      expect(schema).toEqual({
-        title: "MainStruct",
-        type: "object",
-        properties: {
-          main_int: { type: "integer" },
-          nested: {
-            title: "NestedStruct",
-            type: "object",
-            properties: {
-              nested_int: { type: "integer" },
-              nested_float: { type: "number" },
-            },
-          },
-        },
-      });
-    });
-  });
-
   describe("Mocked MCAP File Writes", () => {
     const topicFixture = new Map([
       [
@@ -213,28 +85,22 @@ describe("Create MCAP files from ULog", () => {
     const messageFixture = [
       {
         topic: "sensor_data",
-        message: {
-          timestamp: 1000n,
-          value: 42.0,
-        } as ParsedMessage,
-      },
+        timestamp: 1000n,
+        value: 42.0,
+      } as MockMessage,
       {
         topic: "item_list",
-        message: {
-          timestamp: 2000n,
-          items: [
-            { enabled: true, matrix: [1.0, 0.0, 0.0, 0.0] },
-            { enabled: false, matrix: [0.0, 1.0, 0.0, 0.0] },
-          ],
-        } as ParsedMessage,
-      },
+        timestamp: 2000n,
+        items: [
+          { enabled: true, matrix: [1.0, 0.0, 0.0, 0.0] },
+          { enabled: false, matrix: [0.0, 1.0, 0.0, 0.0] },
+        ],
+      } as MockMessage,
       {
         topic: "sensor_data",
-        message: {
-          timestamp: 3000n,
-          value: 84.0,
-        } as ParsedMessage,
-      },
+        timestamp: 3000n,
+        value: 84.0,
+      } as MockMessage,
     ];
 
     it("should throw an error for missing ULog definitions", async () => {
@@ -244,25 +110,21 @@ describe("Create MCAP files from ULog", () => {
         subscriptions: new Map<number, Subscription>(),
         readMessages: jest.fn(),
       } as unknown as jest.Mocked<ULog>;
-      const mcapWriter = new McapWriter({
-        writable: new TempBuffer(),
-      });
-      await expect(convertULogFileToMCAP(ulogWithoutHeader, mcapWriter, 0n)).rejects.toThrow(
-        "Invalid ULog file: missing header",
-      );
+
+      const buffer = new TempBuffer();
+      await expect(
+        convertULogFileToMCAP(ulogWithoutHeader, new McapWriter({ writable: buffer })),
+      ).rejects.toThrow("Invalid ULog file: missing header");
     });
 
     it("should add channels for all subscriptions", async () => {
       const mockULog = createULogMock({
         messageFields: topicFixture,
-        subscriptions: ["sensor_data", "item_list"],
+        subscriptions: [{ name: "sensor_data" }, { name: "item_list" }],
       });
 
       const mockOutputFile = new TempBuffer();
-      const mcapWriter = new McapWriter({
-        writable: mockOutputFile,
-      });
-      await convertULogFileToMCAP(mockULog, mcapWriter, 0n);
+      await convertULogFileToMCAP(mockULog, new McapWriter({ writable: mockOutputFile }));
 
       const mcapReader = await McapIndexedReader.Initialize({
         readable: mockOutputFile,
@@ -270,38 +132,40 @@ describe("Create MCAP files from ULog", () => {
       const channelNames = Array.from(mcapReader.channelsById.values())
         .map((ch) => ch.topic)
         .sort();
-      expect(channelNames).toEqual(["item_list", "sensor_data"]);
+      expect(channelNames).toStrictEqual(["item_list", "sensor_data"]);
     });
 
     it("should add messages to MCAP with same content", async () => {
       const mockULog = createULogMock({
         messageFields: topicFixture,
-        subscriptions: ["sensor_data", "item_list"],
+        subscriptions: [{ name: "sensor_data" }, { name: "item_list" }],
         messages: messageFixture,
       });
 
       const mockOutputFile = new TempBuffer();
-      const mcapWriter = new McapWriter({
-        writable: mockOutputFile,
-      });
-      await convertULogFileToMCAP(mockULog, mcapWriter, 0n);
+      await convertULogFileToMCAP(mockULog, new McapWriter({ writable: mockOutputFile }));
 
       const mcapReader = await McapIndexedReader.Initialize({
         readable: mockOutputFile,
       });
-      const textDecoder = new TextDecoder();
       const logTimes = [];
       const messageData = [];
       const topics = [];
+      const sequence = [];
       for await (const msg of mcapReader.readMessages()) {
+        const channel = mcapReader.channelsById.get(msg.channelId);
+        const schema = mcapReader.schemasById.get(channel!.schemaId);
+        const protos = protobufFromBinaryDescriptor(schema!.data).lookupType(schema!.name);
         logTimes.push(msg.publishTime);
         topics.push(mcapReader.channelsById.get(msg.channelId)?.topic);
-        messageData.push(JSON.parse(textDecoder.decode(msg.data)));
+        messageData.push(protos.toObject(protos.decode(msg.data)));
+        sequence.push(msg.sequence);
       }
       expect(messageData.length).toBe(messageFixture.length);
-      expect(logTimes).toEqual([1000000n, 2000000n, 3000000n]);
-      expect(topics).toEqual(["sensor_data", "item_list", "sensor_data"]);
-      expect(messageData).toEqual([
+      expect(logTimes).toStrictEqual([1000000n, 2000000n, 3000000n]);
+      expect(sequence).toStrictEqual([0, 0, 1]);
+      expect(topics).toStrictEqual(["sensor_data", "item_list", "sensor_data"]);
+      expect(messageData).toStrictEqual([
         { value: 42.0 },
         {
           items: [
@@ -316,15 +180,14 @@ describe("Create MCAP files from ULog", () => {
     it("should add messages with correct timestamps", async () => {
       const mockULog = createULogMock({
         messageFields: topicFixture,
-        subscriptions: ["sensor_data", "item_list"],
+        subscriptions: [{ name: "sensor_data" }, { name: "item_list" }],
         messages: messageFixture,
       });
 
       const mockOutputFile = new TempBuffer();
-      const mcapWriter = new McapWriter({
-        writable: mockOutputFile,
+      await convertULogFileToMCAP(mockULog, new McapWriter({ writable: mockOutputFile }), {
+        startTime: new Date("2025-01-01"),
       });
-      await convertULogFileToMCAP(mockULog, mcapWriter, 1000n);
 
       const mcapReader = await McapIndexedReader.Initialize({
         readable: mockOutputFile,
@@ -334,7 +197,125 @@ describe("Create MCAP files from ULog", () => {
         logTimes.push(msg.publishTime);
       }
       expect(logTimes.length).toBe(messageFixture.length);
-      expect(logTimes).toEqual([2000000n, 3000000n, 4000000n]);
+      expect(logTimes).toStrictEqual([
+        1735689600001000000n,
+        1735689600002000000n,
+        1735689600003000000n,
+      ]);
+    });
+
+    it("should add separate channels to MCAP for distinct multiIds", async () => {
+      const mockULog = createULogMock({
+        messageFields: topicFixture,
+        subscriptions: [
+          { name: "sensor_data", multiId: 0 },
+          { name: "sensor_data", multiId: 1 },
+          { name: "item_list" },
+        ],
+        messages: [
+          {
+            topic: "sensor_data",
+            timestamp: 1000n,
+            value: 42.0,
+          } as MockMessage,
+          {
+            topic: "sensor_data",
+            multiId: 1,
+            timestamp: 1000n,
+            value: 36.0,
+          } as MockMessage,
+          {
+            topic: "item_list",
+            timestamp: 2000n,
+            items: [
+              { enabled: true, matrix: [1.0, 0.0, 0.0, 0.0] },
+              { enabled: false, matrix: [0.0, 1.0, 0.0, 0.0] },
+            ],
+          } as MockMessage,
+          {
+            topic: "sensor_data",
+            timestamp: 3000n,
+            value: 84.0,
+          } as MockMessage,
+          {
+            topic: "sensor_data",
+            multiId: 1,
+            timestamp: 3000n,
+            value: 64.0,
+          } as MockMessage,
+        ],
+      });
+
+      const mockOutputFile = new TempBuffer();
+      await convertULogFileToMCAP(mockULog, new McapWriter({ writable: mockOutputFile }));
+
+      const mcapReader = await McapIndexedReader.Initialize({
+        readable: mockOutputFile,
+      });
+      const logTimes = [];
+      const messageData = [];
+      const topics = [];
+      const sequence = [];
+      for await (const msg of mcapReader.readMessages()) {
+        const channel = mcapReader.channelsById.get(msg.channelId);
+        const schema = mcapReader.schemasById.get(channel!.schemaId);
+        const protos = protobufFromBinaryDescriptor(schema!.data).lookupType(schema!.name);
+        logTimes.push(msg.publishTime);
+        topics.push(mcapReader.channelsById.get(msg.channelId)?.topic);
+        messageData.push(protos.toObject(protos.decode(msg.data)));
+        sequence.push(msg.sequence);
+      }
+      expect(messageData.length).toBe(5);
+      expect(logTimes).toStrictEqual([1000000n, 1000000n, 2000000n, 3000000n, 3000000n]);
+      expect(sequence).toStrictEqual([0, 0, 0, 1, 1]);
+      expect(topics).toStrictEqual([
+        "sensor_data/0",
+        "sensor_data/1",
+        "item_list",
+        "sensor_data/0",
+        "sensor_data/1",
+      ]);
+      expect(messageData).toStrictEqual([
+        { value: 42.0 },
+        { value: 36.0 },
+        {
+          items: [
+            { enabled: true, matrix: [1.0, 0.0, 0.0, 0.0] },
+            { enabled: false, matrix: [0.0, 1.0, 0.0, 0.0] },
+          ],
+        },
+        { value: 84.0 },
+        { value: 64.0 },
+      ]);
+    });
+
+    it("should add metadata to the mcap file", async () => {
+      const mockULog = createULogMock({
+        messageFields: topicFixture,
+        subscriptions: [{ name: "sensor_data" }, { name: "item_list" }],
+      });
+
+      const metadataFields = new Map<string, string>();
+      metadataFields.set("foo", "bar");
+      const metadata = { name: "foxglove", metadata: metadataFields } as Metadata;
+
+      const mockOutputFile = new TempBuffer();
+      await convertULogFileToMCAP(mockULog, new McapWriter({ writable: mockOutputFile }), {
+        metadata: [metadata],
+      });
+
+      const mcapReader = await McapIndexedReader.Initialize({
+        readable: mockOutputFile,
+      });
+
+      const storedMetadata = [];
+
+      for await (const m of mcapReader.readMetadata()) {
+        storedMetadata.push(m);
+      }
+
+      expect(storedMetadata).toHaveLength(1);
+      expect(storedMetadata[0]!).toStrictEqual({ type: "Metadata", ...metadata });
     });
 
     it("should handle bigint conversions to integer", async () => {
@@ -348,33 +329,30 @@ describe("Create MCAP files from ULog", () => {
             ],
           ],
         ]),
-        subscriptions: ["sensor_data"],
+        subscriptions: [{ name: "sensor_data" }],
         messages: [
           {
             topic: "sensor_data",
-            message: {
-              timestamp: 1000n,
-              value: 100000000000n,
-            } as ParsedMessage,
-          },
+            timestamp: 1000n,
+            value: 18446744073709551615n,
+          } as MockMessage,
         ],
       });
 
       const mockOutputFile = new TempBuffer();
-      const mcapWriter = new McapWriter({
-        writable: mockOutputFile,
-      });
-      await convertULogFileToMCAP(mockULog, mcapWriter, 0n);
+      await convertULogFileToMCAP(mockULog, new McapWriter({ writable: mockOutputFile }));
       const mcapReader = await McapIndexedReader.Initialize({
         readable: mockOutputFile,
       });
-      const textDecoder = new TextDecoder();
       const messageData = [];
       for await (const msg of mcapReader.readMessages()) {
-        messageData.push(JSON.parse(textDecoder.decode(msg.data)));
+        const channel = mcapReader.channelsById.get(msg.channelId);
+        const schema = mcapReader.schemasById.get(channel!.schemaId);
+        const protos = protobufFromBinaryDescriptor(schema!.data).lookupType(schema!.name);
+        messageData.push(protos.toObject(protos.decode(msg.data), { longs: BigInt }));
       }
       expect(messageData.length).toBe(1);
-      expect(messageData).toEqual([{ value: 100000000000 }]);
+      expect(messageData).toStrictEqual([{ value: Long.fromString("18446744073709551615", true) }]);
     });
   });
 
@@ -382,10 +360,10 @@ describe("Create MCAP files from ULog", () => {
     const inputFileHandle = new FileReader(__dirname + "/fixtures/test_ulog.ulg");
 
     const mockOutputFile = new TempBuffer();
-    const mcapWriter = new McapWriter({
-      writable: mockOutputFile,
-    });
-    await convertULogFileToMCAP(new ULog(inputFileHandle), mcapWriter, 1_000n);
+    await convertULogFileToMCAP(
+      new ULog(inputFileHandle),
+      new McapWriter({ writable: mockOutputFile }),
+    );
 
     const mcapReader = await McapIndexedReader.Initialize({
       readable: mockOutputFile,

--- a/src/convert.test.ts
+++ b/src/convert.test.ts
@@ -1,0 +1,397 @@
+import { McapIndexedReader, TempBuffer, McapWriter } from "@mcap/core";
+
+import { ULog, Subscription } from "./ULog";
+import { ulogDefinitionToJSONSchema, convertULogFileToMCAP } from "./convert";
+import { MessageDefinition, Field } from "./definition";
+import { MessageType } from "./enums";
+import { ParsedMessage } from "./messages";
+import { FileReader } from "./node/FileReader";
+
+function createULogMock({
+  messageFields,
+  subscriptions,
+  timestamp = 0n,
+  messages = [],
+}: {
+  messageFields: Map<string, Field[]>;
+  subscriptions: string[];
+  timestamp?: bigint;
+  messages?: { topic: string; message: ParsedMessage }[];
+}): jest.Mocked<ULog> {
+  const msgIds = new Map<string, number>();
+  const definitions = new Map<string, MessageDefinition>();
+  messageFields.forEach((fields, name) => {
+    definitions.set(name, {
+      name,
+      fields,
+      format: "not read",
+    } as MessageDefinition);
+  });
+  const subscriptionMap = new Map<number, Subscription>();
+  subscriptions.forEach((name, index) => {
+    msgIds.set(name, index + 1);
+    subscriptionMap.set(index + 1, {
+      multiId: index + 1,
+      ...definitions.get(name)!,
+    });
+  });
+  const ulogMock: jest.Mocked<ULog> = {
+    open: jest.fn().mockResolvedValue(undefined),
+    header: {
+      timestamp,
+      definitions,
+    },
+    subscriptions: subscriptionMap,
+    readMessages: jest.fn().mockImplementation(async function* () {
+      for (const msg of messages) {
+        yield {
+          type: MessageType.Data,
+          msgId: msgIds.get(msg.topic)!,
+          value: msg.message,
+        };
+      }
+    }),
+  } as unknown as jest.Mocked<ULog>;
+  return ulogMock;
+}
+
+describe("Create MCAP files from ULog", () => {
+  describe("Schema Conversion", () => {
+    it("should throw an error for missing ULog definitions", () => {
+      const definitions = new Map<string, MessageDefinition>();
+      expect(() => {
+        ulogDefinitionToJSONSchema("NonExistentSchema", definitions);
+      }).toThrow("Missing ULog definition for message type: NonExistentSchema");
+    });
+
+    it("should convert primitive field types", () => {
+      const definition = {
+        name: "TestSchema",
+        fields: [
+          { name: "uint_1", type: "uint8_t", isComplex: false },
+          { name: "uint_2", type: "uint16_t", isComplex: false },
+          { name: "uint_3", type: "uint32_t", isComplex: false },
+          { name: "uint_4", type: "uint64_t", isComplex: false },
+          { name: "int_1", type: "int8_t", isComplex: false },
+          { name: "int_2", type: "int16_t", isComplex: false },
+          { name: "int_3", type: "int32_t", isComplex: false },
+          { name: "int_4", type: "int64_t", isComplex: false },
+          { name: "float_1", type: "float", isComplex: false },
+          { name: "float_2", type: "double", isComplex: false },
+          { name: "bool", type: "bool", isComplex: false },
+          { name: "string", type: "char", isComplex: false },
+          { name: "string", type: "char", arrayLength: 4, isComplex: false },
+          { name: "string", type: "char", arrayLength: 20, isComplex: false },
+        ],
+        format: "not read",
+      };
+      const definitions = new Map<string, MessageDefinition>();
+      definitions.set("TestSchema", definition);
+      const schemaName = "TestSchema";
+      const schema = ulogDefinitionToJSONSchema(schemaName, definitions);
+      expect(schema).toEqual({
+        title: "TestSchema",
+        type: "object",
+        properties: {
+          uint_1: { type: "integer" },
+          uint_2: { type: "integer" },
+          uint_3: { type: "integer" },
+          uint_4: { type: "integer" },
+          int_1: { type: "integer" },
+          int_2: { type: "integer" },
+          int_3: { type: "integer" },
+          int_4: { type: "integer" },
+          float_1: { type: "number" },
+          float_2: { type: "number" },
+          bool: { type: "boolean" },
+          string: { type: "string" },
+        },
+      });
+    });
+
+    it("should convert array field types correctly", () => {
+      const definition = {
+        name: "ArraySchema",
+        fields: [
+          { name: "array_int", type: "uint8_t", arrayLength: 4, isComplex: false },
+          { name: "array_int16", type: "int16_t", arrayLength: 2, isComplex: false },
+          { name: "array_float", type: "float", arrayLength: 3, isComplex: false },
+          { name: "string_type", type: "char", arrayLength: 5, isComplex: false }, // Should be treated as string, not array
+        ],
+        format: "not read",
+      };
+      const definitions = new Map<string, MessageDefinition>();
+      definitions.set("ArraySchema", definition);
+      const schemaName = "ArraySchema";
+      const schema = ulogDefinitionToJSONSchema(schemaName, definitions);
+      expect(schema).toEqual({
+        title: "ArraySchema",
+        type: "object",
+        properties: {
+          array_int: {
+            type: "array",
+            items: { type: "integer" },
+            minItems: 4,
+            maxItems: 4,
+          },
+          array_int16: {
+            type: "array",
+            items: { type: "integer" },
+            minItems: 2,
+            maxItems: 2,
+          },
+          array_float: {
+            type: "array",
+            items: { type: "number" },
+            minItems: 3,
+            maxItems: 3,
+          },
+          string_type: { type: "string" },
+        },
+      });
+    });
+
+    it("should convert nested struct field types correctly", () => {
+      const nestedDefinition = {
+        name: "NestedStruct",
+        fields: [
+          { name: "nested_int", type: "int32_t", isComplex: false },
+          { name: "nested_float", type: "float", isComplex: false },
+        ],
+        format: "not read",
+      };
+      const mainDefinition = {
+        name: "MainStruct",
+        fields: [
+          { name: "main_int", type: "uint16_t", isComplex: false },
+          { name: "nested", type: "NestedStruct", isComplex: true },
+        ],
+        format: "not read",
+      };
+      const definitions = new Map<string, MessageDefinition>();
+      definitions.set("NestedStruct", nestedDefinition);
+      definitions.set("MainStruct", mainDefinition);
+      const schemaName = "MainStruct";
+      const schema = ulogDefinitionToJSONSchema(schemaName, definitions);
+      expect(schema).toEqual({
+        title: "MainStruct",
+        type: "object",
+        properties: {
+          main_int: { type: "integer" },
+          nested: {
+            title: "NestedStruct",
+            type: "object",
+            properties: {
+              nested_int: { type: "integer" },
+              nested_float: { type: "number" },
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe("Mocked MCAP File Writes", () => {
+    const topicFixture = new Map([
+      [
+        "sensor_data",
+        [
+          { name: "timestamp", type: "uint64_t", isComplex: false },
+          { name: "value", type: "float", isComplex: false },
+        ],
+      ],
+      [
+        "item_definition",
+        [
+          { name: "enabled", type: "bool", isComplex: false },
+          { name: "matrix", type: "float", arrayLength: 4, isComplex: false },
+        ],
+      ],
+      ["item_list", [{ name: "items", type: "item_definition", arrayLength: 2, isComplex: true }]],
+    ]);
+
+    const messageFixture = [
+      {
+        topic: "sensor_data",
+        message: {
+          timestamp: 1000n,
+          value: 42.0,
+        } as ParsedMessage,
+      },
+      {
+        topic: "item_list",
+        message: {
+          timestamp: 2000n,
+          items: [
+            { enabled: true, matrix: [1.0, 0.0, 0.0, 0.0] },
+            { enabled: false, matrix: [0.0, 1.0, 0.0, 0.0] },
+          ],
+        } as ParsedMessage,
+      },
+      {
+        topic: "sensor_data",
+        message: {
+          timestamp: 3000n,
+          value: 84.0,
+        } as ParsedMessage,
+      },
+    ];
+
+    it("should throw an error for missing ULog definitions", async () => {
+      const ulogWithoutHeader = {
+        open: jest.fn().mockResolvedValue(undefined),
+        header: undefined,
+        subscriptions: new Map<number, Subscription>(),
+        readMessages: jest.fn(),
+      } as unknown as jest.Mocked<ULog>;
+      const mcapWriter = new McapWriter({
+        writable: new TempBuffer(),
+      });
+      await expect(convertULogFileToMCAP(ulogWithoutHeader, mcapWriter, 0n)).rejects.toThrow(
+        "Invalid ULog file: missing header",
+      );
+    });
+
+    it("should add channels for all subscriptions", async () => {
+      const mockULog = createULogMock({
+        messageFields: topicFixture,
+        subscriptions: ["sensor_data", "item_list"],
+      });
+
+      const mockOutputFile = new TempBuffer();
+      const mcapWriter = new McapWriter({
+        writable: mockOutputFile,
+      });
+      await convertULogFileToMCAP(mockULog, mcapWriter, 0n);
+
+      const mcapReader = await McapIndexedReader.Initialize({
+        readable: mockOutputFile,
+      });
+      const channelNames = Array.from(mcapReader.channelsById.values())
+        .map((ch) => ch.topic)
+        .sort();
+      expect(channelNames).toEqual(["item_list", "sensor_data"]);
+    });
+
+    it("should add messages to MCAP with same content", async () => {
+      const mockULog = createULogMock({
+        messageFields: topicFixture,
+        subscriptions: ["sensor_data", "item_list"],
+        messages: messageFixture,
+      });
+
+      const mockOutputFile = new TempBuffer();
+      const mcapWriter = new McapWriter({
+        writable: mockOutputFile,
+      });
+      await convertULogFileToMCAP(mockULog, mcapWriter, 0n);
+
+      const mcapReader = await McapIndexedReader.Initialize({
+        readable: mockOutputFile,
+      });
+      const textDecoder = new TextDecoder();
+      const logTimes = [];
+      const messageData = [];
+      const topics = [];
+      for await (const msg of mcapReader.readMessages()) {
+        logTimes.push(msg.publishTime);
+        topics.push(mcapReader.channelsById.get(msg.channelId)?.topic);
+        messageData.push(JSON.parse(textDecoder.decode(msg.data)));
+      }
+      expect(messageData.length).toBe(messageFixture.length);
+      expect(logTimes).toEqual([1000000n, 2000000n, 3000000n]);
+      expect(topics).toEqual(["sensor_data", "item_list", "sensor_data"]);
+      expect(messageData).toEqual([
+        { value: 42.0 },
+        {
+          items: [
+            { enabled: true, matrix: [1.0, 0.0, 0.0, 0.0] },
+            { enabled: false, matrix: [0.0, 1.0, 0.0, 0.0] },
+          ],
+        },
+        { value: 84.0 },
+      ]);
+    });
+
+    it("should add messages with correct timestamps", async () => {
+      const mockULog = createULogMock({
+        messageFields: topicFixture,
+        subscriptions: ["sensor_data", "item_list"],
+        messages: messageFixture,
+      });
+
+      const mockOutputFile = new TempBuffer();
+      const mcapWriter = new McapWriter({
+        writable: mockOutputFile,
+      });
+      await convertULogFileToMCAP(mockULog, mcapWriter, 1000n);
+
+      const mcapReader = await McapIndexedReader.Initialize({
+        readable: mockOutputFile,
+      });
+      const logTimes = [];
+      for await (const msg of mcapReader.readMessages()) {
+        logTimes.push(msg.publishTime);
+      }
+      expect(logTimes.length).toBe(messageFixture.length);
+      expect(logTimes).toEqual([2000000n, 3000000n, 4000000n]);
+    });
+
+    it("should handle bigint conversions to integer", async () => {
+      const mockULog = createULogMock({
+        messageFields: new Map([
+          [
+            "sensor_data",
+            [
+              { name: "timestamp", type: "uint64_t", isComplex: false },
+              { name: "value", type: "uint64_t", isComplex: false },
+            ],
+          ],
+        ]),
+        subscriptions: ["sensor_data"],
+        messages: [
+          {
+            topic: "sensor_data",
+            message: {
+              timestamp: 1000n,
+              value: 100000000000n,
+            } as ParsedMessage,
+          },
+        ],
+      });
+
+      const mockOutputFile = new TempBuffer();
+      const mcapWriter = new McapWriter({
+        writable: mockOutputFile,
+      });
+      await convertULogFileToMCAP(mockULog, mcapWriter, 0n);
+      const mcapReader = await McapIndexedReader.Initialize({
+        readable: mockOutputFile,
+      });
+      const textDecoder = new TextDecoder();
+      const messageData = [];
+      for await (const msg of mcapReader.readMessages()) {
+        messageData.push(JSON.parse(textDecoder.decode(msg.data)));
+      }
+      expect(messageData.length).toBe(1);
+      expect(messageData).toEqual([{ value: 100000000000 }]);
+    });
+  });
+
+  it("should perform full ULog to MCAP conversion with sample files", async () => {
+    const inputFileHandle = new FileReader(__dirname + "/fixtures/test_ulog.ulg");
+
+    const mockOutputFile = new TempBuffer();
+    const mcapWriter = new McapWriter({
+      writable: mockOutputFile,
+    });
+    await convertULogFileToMCAP(new ULog(inputFileHandle), mcapWriter, 1_000n);
+
+    const mcapReader = await McapIndexedReader.Initialize({
+      readable: mockOutputFile,
+    });
+
+    const channelTopics = Array.from(mcapReader.channelsById.values()).map((ch) => ch.topic);
+    expect(channelTopics.length).toBe(114);
+  });
+});

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,0 +1,146 @@
+import { McapWriter } from "@mcap/core";
+
+import { ULog } from "./ULog";
+import { MessageDefinition } from "./definition";
+import { MessageType } from "./enums";
+import { ParsedMessage, FieldArray, FieldPrimitive, FieldStruct } from "./messages";
+
+type MessageMinusTimestamp = Omit<ParsedMessage, "timestamp">;
+
+function ulogFieldTypeToJSONPrimitive(fieldType: string): string | undefined {
+  switch (fieldType) {
+    case "bool":
+      return "boolean";
+    case "char":
+      return "string";
+    case "float":
+    case "double":
+      return "number";
+    case "int8_t":
+    case "uint8_t":
+    case "int16_t":
+    case "uint16_t":
+    case "int32_t":
+    case "uint32_t":
+    case "int64_t":
+    case "uint64_t":
+      return "integer";
+    default:
+      return undefined;
+  }
+}
+
+export function ulogDefinitionToJSONSchema(
+  schemaName: string,
+  definitions: Map<string, MessageDefinition>,
+): object {
+  const definition = definitions.get(schemaName);
+  if (definition == undefined) {
+    throw new Error(`Missing ULog definition for message type: ${schemaName}`);
+  }
+  const jsonFields: Record<string, object> = {};
+
+  for (const field of definition.fields) {
+    if (field.name === "timestamp" || field.name.startsWith("_padding")) {
+      continue; // Skip special fields
+    }
+
+    const primitiveType = ulogFieldTypeToJSONPrimitive(field.type);
+
+    let fieldSchema: object;
+    if (primitiveType == undefined) {
+      fieldSchema = ulogDefinitionToJSONSchema(field.type, definitions);
+    } else {
+      fieldSchema = { type: primitiveType };
+    }
+
+    if (field.arrayLength != undefined && primitiveType !== "string") {
+      fieldSchema = {
+        type: "array",
+        items: fieldSchema,
+        minItems: field.arrayLength,
+        maxItems: field.arrayLength,
+      };
+    }
+    jsonFields[field.name] = fieldSchema;
+  }
+
+  return {
+    title: schemaName,
+    type: "object",
+    properties: jsonFields,
+  };
+}
+
+/**
+ * Read a ULog file and convert it to MCAP format.
+ * @param inputFile - the ULog file handle to convert
+ * @param outputFile - the MCAP file writer to write to
+ * @param startTime - the initial time to use for message timestamps (in microseconds). This is required since ULog timestamps are often only relative to device startup.
+ */
+export async function convertULogFileToMCAP(
+  inputFile: ULog,
+  outputFile: McapWriter,
+  startTime: bigint,
+): Promise<void> {
+  await inputFile.open();
+  if (inputFile.header == undefined) {
+    throw new Error("Invalid ULog file: missing header");
+  }
+
+  await outputFile.start({
+    profile: "",
+    library: "ulog conversion",
+  });
+
+  const fileStartTime = inputFile.header.timestamp;
+
+  // Register schemas and channels
+  const msgIdToChannelId = new Map<number, number>();
+  for (const [msgId, subscription] of inputFile.subscriptions.entries()) {
+    const channelName = subscription.name;
+    const schema = ulogDefinitionToJSONSchema(channelName, inputFile.header.definitions);
+    const schemaId = await outputFile.registerSchema({
+      name: channelName,
+      encoding: "jsonschema",
+      data: Buffer.from(JSON.stringify(schema)),
+    });
+
+    const channelId = await outputFile.registerChannel({
+      schemaId,
+      topic: channelName,
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    msgIdToChannelId.set(msgId, channelId);
+  }
+
+  // Read messages and write to MCAP
+  for await (const msg of inputFile.readMessages()) {
+    if (msg.type === MessageType.Data) {
+      const channelId = msgIdToChannelId.get(msg.msgId);
+      if (channelId == undefined) {
+        throw new Error(`No channel ID found for message ID: ${msg.msgId}`);
+      }
+
+      const msgTimestamp = (msg.value.timestamp - fileStartTime + startTime) * 1000n;
+      const msgData: MessageMinusTimestamp = { ...msg.value };
+      delete msgData.timestamp;
+      await outputFile.addMessage({
+        channelId,
+        sequence: 0,
+        publishTime: msgTimestamp,
+        logTime: msgTimestamp,
+        data: Buffer.from(
+          JSON.stringify(
+            msgData,
+            (_, value: FieldStruct | FieldPrimitive | FieldArray) =>
+              typeof value === "bigint" ? Number(value) : value, // We can afford loss of precision here because we are generating test data
+          ),
+        ),
+      });
+    }
+  }
+
+  await outputFile.end();
+}

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,120 +1,193 @@
 import { McapWriter } from "@mcap/core";
+import { Metadata } from "@mcap/core/src/types";
+import { protobufToDescriptor } from "@mcap/support";
+import protobufjs from "protobufjs";
+import descriptor from "protobufjs/ext/descriptor";
 
 import { ULog } from "./ULog";
 import { MessageDefinition } from "./definition";
 import { MessageType } from "./enums";
-import { ParsedMessage, FieldArray, FieldPrimitive, FieldStruct } from "./messages";
 
-type MessageMinusTimestamp = Omit<ParsedMessage, "timestamp">;
-
-function ulogFieldTypeToJSONPrimitive(fieldType: string): string | undefined {
+function ulogFieldTypeToProtobufFieldType(fieldType: string): string | undefined {
   switch (fieldType) {
     case "bool":
-      return "boolean";
+      return "bool";
     case "char":
       return "string";
     case "float":
+      return "float";
     case "double":
-      return "number";
+      return "double";
     case "int8_t":
-    case "uint8_t":
     case "int16_t":
-    case "uint16_t":
     case "int32_t":
+      return "int32";
+    case "uint8_t":
+    case "uint16_t":
     case "uint32_t":
+      return "uint32";
     case "int64_t":
+      return "int64";
     case "uint64_t":
-      return "integer";
+      return "uint64";
     default:
       return undefined;
   }
 }
 
-export function ulogDefinitionToJSONSchema(
-  schemaName: string,
-  definitions: Map<string, MessageDefinition>,
-): object {
-  const definition = definitions.get(schemaName);
-  if (definition == undefined) {
-    throw new Error(`Missing ULog definition for message type: ${schemaName}`);
+/** Convert ULog message definitions to a Protobuf root and dependencies map. */
+function ulogDefinitionsToProtobufTypes(definitions: Map<string, MessageDefinition>): {
+  typeMap: Map<string, protobufjs.Type>;
+  dependencies: Map<string, Array<string>>;
+} {
+  const typeMap = new Map<string, protobufjs.Type>();
+  const dependencies = new Map<string, Array<string>>();
+  for (const [schemaName, definition] of definitions) {
+    const fieldTypeProto = new protobufjs.Type(schemaName);
+    let id = 0;
+    for (const field of definition.fields) {
+      // Omit special fields
+      // Timestamp is used for message log time so it's not required in the message body
+      // _padding0 is a padding field and contains no data
+      if (field.name === "timestamp" || field.name.startsWith("_padding")) {
+        continue;
+      }
+
+      const primitiveType = ulogFieldTypeToProtobufFieldType(field.type);
+      const fieldType = primitiveType ?? field.type;
+      if (primitiveType == undefined) {
+        // Record dependency
+        if (!dependencies.has(schemaName)) {
+          dependencies.set(schemaName, []);
+        }
+        dependencies.get(schemaName)!.push(field.type);
+      }
+      const rule =
+        field.arrayLength != undefined && primitiveType !== "string" ? "repeated" : "required";
+
+      fieldTypeProto.add(new protobufjs.Field(field.name, id, fieldType, rule));
+      id += 1;
+    }
+    typeMap.set(schemaName, fieldTypeProto);
   }
-  const jsonFields: Record<string, object> = {};
 
-  for (const field of definition.fields) {
-    if (field.name === "timestamp" || field.name.startsWith("_padding")) {
-      continue; // Skip special fields
+  return { typeMap, dependencies };
+}
+
+/** Create a new protobuf Root with only the types required for one root schema */
+function getMinimalProtobufRoot(
+  rootName: string,
+  typeMap: Map<string, protobufjs.Type>,
+  dependencies: Map<string, Array<string>>,
+): protobufjs.Root {
+  const minimalRoot = new protobufjs.Root();
+  const typesToProcess = new Set<string>();
+  typesToProcess.add(rootName);
+  const processed = new Set<string>();
+
+  while (typesToProcess.size > 0) {
+    const typeName = typesToProcess.values().next().value!;
+    typesToProcess.delete(typeName);
+    const type = typeMap.get(typeName);
+    if (type == undefined) {
+      throw new Error(`Type ${typeName} not found in type map`);
     }
-
-    const primitiveType = ulogFieldTypeToJSONPrimitive(field.type);
-
-    let fieldSchema: object;
-    if (primitiveType == undefined) {
-      fieldSchema = ulogDefinitionToJSONSchema(field.type, definitions);
-    } else {
-      fieldSchema = { type: primitiveType };
+    minimalRoot.add(type);
+    processed.add(typeName);
+    for (const dependentType of dependencies.get(typeName) ?? []) {
+      if (!processed.has(dependentType)) {
+        typesToProcess.add(dependentType);
+      }
     }
-
-    if (field.arrayLength != undefined && primitiveType !== "string") {
-      fieldSchema = {
-        type: "array",
-        items: fieldSchema,
-        minItems: field.arrayLength,
-        maxItems: field.arrayLength,
-      };
-    }
-    jsonFields[field.name] = fieldSchema;
   }
-
-  return {
-    title: schemaName,
-    type: "object",
-    properties: jsonFields,
-  };
+  return minimalRoot;
 }
 
 /**
  * Read a ULog file and convert it to MCAP format.
- * @param inputFile - the ULog file handle to convert
- * @param outputFile - the MCAP file writer to write to
- * @param startTime - the initial time to use for message timestamps (in microseconds). This is required since ULog timestamps are often only relative to device startup.
+ * @param inputFile - The ULog file handle to convert
+ * @param outputFile - The MCAP file handle to write to
+ * @param options - Optional parameters
+ * @param options.startTime - The initial time to use for message timestamps (in microseconds).
+ *                    Recommended since ULog timestamps are often only relative to device startup.
+ * @param options.metadata - Optional list of Metadata objects to add to the file.
  */
 export async function convertULogFileToMCAP(
   inputFile: ULog,
   outputFile: McapWriter,
-  startTime: bigint,
+  options?: {
+    startTime?: Date;
+    metadata?: Metadata[];
+  },
 ): Promise<void> {
   await inputFile.open();
   if (inputFile.header == undefined) {
     throw new Error("Invalid ULog file: missing header");
   }
+  if (inputFile.header.version !== 1) {
+    throw new Error(`Unknown ULog file verion: ${inputFile.header.version}`);
+  }
 
   await outputFile.start({
     profile: "",
-    library: "ulog conversion",
+    library: "ulog conversion 0.0.1",
   });
+  if (options?.metadata != undefined) {
+    for (const metadataItem of options.metadata) {
+      await outputFile.addMetadata(metadataItem);
+    }
+  }
 
-  const fileStartTime = inputFile.header.timestamp;
+  // Ulog records the timestamp at the start of recording and the timestamps of each message as microseconnds since device startup
+  // When absolute start time is provided, we subtract the recording start timestamp from each message timestamp to get microseconds
+  // since recording start and add that to the new start time to get microseconds since epoch
+  const deviceRecordingStartTime = inputFile.header.timestamp;
+  const startTimestampOffset =
+    options?.startTime != undefined
+      ? BigInt(options.startTime.getTime()) * 1_000n - deviceRecordingStartTime
+      : 0n;
 
+  const { typeMap, dependencies } = ulogDefinitionsToProtobufTypes(inputFile.header.definitions);
   // Register schemas and channels
+  const numSubscriptions = new Map<string, number>();
+  for (const subscription of inputFile.subscriptions.values()) {
+    const count = numSubscriptions.get(subscription.name) ?? 0;
+    numSubscriptions.set(subscription.name, count + 1);
+  }
+
   const msgIdToChannelId = new Map<number, number>();
+  const msgIdToSchema = new Map<number, protobufjs.Type>();
+  const schemaNameToSchemaId = new Map<string, number>();
   for (const [msgId, subscription] of inputFile.subscriptions.entries()) {
-    const channelName = subscription.name;
-    const schema = ulogDefinitionToJSONSchema(channelName, inputFile.header.definitions);
-    const schemaId = await outputFile.registerSchema({
-      name: channelName,
-      encoding: "jsonschema",
-      data: Buffer.from(JSON.stringify(schema)),
-    });
+    const channelName =
+      (numSubscriptions.get(subscription.name) ?? 1) === 1
+        ? subscription.name
+        : `${subscription.name}/${subscription.multiId}`;
+    const minimalRoot = getMinimalProtobufRoot(subscription.name, typeMap, dependencies);
+    const descriptorSet = protobufToDescriptor(minimalRoot);
+    const msgType = minimalRoot.lookupType(subscription.name);
+
+    let schemaId = schemaNameToSchemaId.get(subscription.name);
+    if (schemaId == undefined) {
+      schemaId = await outputFile.registerSchema({
+        name: subscription.name,
+        encoding: "protobuf",
+        data: descriptor.FileDescriptorSet.encode(descriptorSet).finish(),
+      });
+      schemaNameToSchemaId.set(subscription.name, schemaId);
+    }
 
     const channelId = await outputFile.registerChannel({
       schemaId,
       topic: channelName,
-      messageEncoding: "json",
+      messageEncoding: "protobuf",
       metadata: new Map(),
     });
     msgIdToChannelId.set(msgId, channelId);
+    msgIdToSchema.set(msgId, msgType);
   }
 
+  const channelIdToSequence = new Map<number, number>();
   // Read messages and write to MCAP
   for await (const msg of inputFile.readMessages()) {
     if (msg.type === MessageType.Data) {
@@ -123,22 +196,23 @@ export async function convertULogFileToMCAP(
         throw new Error(`No channel ID found for message ID: ${msg.msgId}`);
       }
 
-      const msgTimestamp = (msg.value.timestamp - fileStartTime + startTime) * 1000n;
-      const msgData: MessageMinusTimestamp = { ...msg.value };
-      delete msgData.timestamp;
+      const sequenceNumber = channelIdToSequence.get(channelId) ?? 0;
+      const { timestamp, ...msgData } = msg.value;
+      const msgTimestamp = (startTimestampOffset + timestamp) * 1000n; // convert microseconds to nanoseconds
+
+      const msgType = msgIdToSchema.get(msg.msgId);
+      if (msgType == undefined) {
+        throw new Error(`No message schema found for message ID: ${msg.msgId}`);
+      }
+      const protoMsg = msgType.fromObject(msgData);
       await outputFile.addMessage({
         channelId,
-        sequence: 0,
+        sequence: sequenceNumber,
         publishTime: msgTimestamp,
         logTime: msgTimestamp,
-        data: Buffer.from(
-          JSON.stringify(
-            msgData,
-            (_, value: FieldStruct | FieldPrimitive | FieldArray) =>
-              typeof value === "bigint" ? Number(value) : value, // We can afford loss of precision here because we are generating test data
-          ),
-        ),
+        data: msgType.encode(protoMsg).finish(),
       });
+      channelIdToSequence.set(channelId, sequenceNumber + 1);
     }
   }
 

--- a/src/fixtures/test_ulog.ulg
+++ b/src/fixtures/test_ulog.ulg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7a7db5b919367f8f92492187fe6959b19af96bb407044d2729e19ebdc7b0352
+size 372168

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export * from "./file";
 export * from "./messages";
 export * from "./parse";
 export * from "./ULog";
-export { convertULogFileToMCAP } from "./convert";
+export * from "./convert";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./file";
 export * from "./messages";
 export * from "./parse";
 export * from "./ULog";
+export { convertULogFileToMCAP } from "./convert";

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,7 +494,7 @@ __metadata:
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
     prettier: "npm:3.5.3"
-    protobufjs: "npm:^8.0.0"
+    protobufjs: "npm:^7.2.5"
     rimraf: "npm:6.0.1"
     ts-jest: "npm:29.3.2"
     typescript: "npm:5.8.3"
@@ -5635,26 +5635,6 @@ __metadata:
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
   checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "protobufjs@npm:8.0.0"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/6fb29ca3c6abc2095a777407750f6094448b7b68bbf04147ec49ee442f85f151592338449f56d19883ea67c39ce915e3d47ec6c5c92f0bcac1eaba1841ab84ff
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,7 @@ __metadata:
     "@foxglove/eslint-plugin": "npm:2.0.0"
     "@mcap/core": "npm:^2.1.7"
     "@mcap/nodejs": "npm:^1.0.2"
+    "@mcap/support": "npm:^1.0.4"
     "@types/jest": "npm:29.5.14"
     eslint: "npm:9.26.0"
     eslint-config-prettier: "npm:8.10.0"
@@ -493,12 +494,36 @@ __metadata:
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
     prettier: "npm:3.5.3"
+    protobufjs: "npm:^8.0.0"
     rimraf: "npm:6.0.1"
     ts-jest: "npm:29.3.2"
     typescript: "npm:5.8.3"
     typescript-eslint: "npm:8.32.0"
   languageName: unknown
   linkType: soft
+
+"@foxglove/wasm-bz2@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@foxglove/wasm-bz2@npm:0.1.1"
+  dependencies:
+    tslib: "npm:^2"
+  checksum: 10c0/6a684aaf33324782b8a2eb14b9078e9da1188c5c89eadca79d2afb94fcc22518f28b08d8860b56088d081e35d9007d0e357c69f04105292abf00aa889742ff0d
+  languageName: node
+  linkType: hard
+
+"@foxglove/wasm-lz4@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@foxglove/wasm-lz4@npm:1.0.2"
+  checksum: 10c0/93832a905c77cdc8e7295154becb5e4fb9933feea7b9739cd645f32bb849266fea3c1a866be6c1f49f190b7046e20032f31f1943a063a8c464c40445a66194ec
+  languageName: node
+  linkType: hard
+
+"@foxglove/wasm-zstd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@foxglove/wasm-zstd@npm:1.0.1"
+  checksum: 10c0/32436037a2d9ed043225d217c789cfa7e17715f28646b7911d8995bf4a68f03c3e2624f5192051cf52e21210c8dddef125c6b5fcb75d90d9b15e4551d54dcfb3
+  languageName: node
+  linkType: hard
 
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
@@ -864,6 +889,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mcap/support@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@mcap/support@npm:1.0.4"
+  dependencies:
+    "@foxglove/wasm-bz2": "npm:^0.1.1"
+    "@foxglove/wasm-lz4": "npm:^1.0.2"
+    "@foxglove/wasm-zstd": "npm:^1.0.1"
+    protobufjs: "npm:^7.2.5"
+    tslib: "npm:^2.5.0"
+  checksum: 10c0/03c58ff1c6bfa2c7415b8fc892549395ab3ac4c6efd5728414aa029c3d036850dd5a16985c3747592148ab0fc37d8c0e0af153657b835be6a5326aace7bda115
+  languageName: node
+  linkType: hard
+
 "@modelcontextprotocol/sdk@npm:^1.8.0":
   version: 1.11.0
   resolution: "@modelcontextprotocol/sdk@npm:1.11.0"
@@ -942,6 +980,79 @@ __metadata:
   version: 0.2.4
   resolution: "@pkgr/core@npm:0.2.4"
   checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10c0/a83343a468ff5b5ec6bff36fd788a64c839e48a07ff9f4f813564f58caf44d011cd6504ed2147bf34835bd7a7dd2107052af755961c6b098fd8902b4f6500d0f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10c0/eec925e681081af190b8ee231f9bad3101e189abbc182ff279da6b531e7dbd2a56f1f306f37a80b1be9e00aa2d271690d08dcc5f326f71c9eed8546675c8caf6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+    "@protobufjs/inquire": "npm:^1.1.0"
+  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10c0/cece0a938e7f5dfd2fa03f8c14f2f1cf8b0d6e13ac7326ff4c96ea311effd5fb7ae0bba754fbf505312af2e38500250c90e68506b97c02360a43793d88a0d8b4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10c0/eda2718b7f222ac6e6ad36f758a92ef90d26526026a19f4f17f668f45e0306a5bd734def3f48f51f8134ae0978b6262a5c517c08b115a551756d1a3aadfcf038
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
   languageName: node
   linkType: hard
 
@@ -1105,6 +1216,15 @@ __metadata:
   version: 17.0.10
   resolution: "@types/node@npm:17.0.10"
   checksum: 10c0/d250b5b010d84d7d5e0aaba90b50826bfce1b31e3359e2f277fbe2184fbaa7142d51c48c69973504f337f58370cd32ed4040816b36b4c7e9524cd07631bc457e
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=13.7.0":
+  version: 25.0.3
+  resolution: "@types/node@npm:25.0.3"
+  dependencies:
+    undici-types: "npm:~7.16.0"
+  checksum: 10c0/b7568f0d765d9469621615e2bb257c7fd1953d95e9acbdb58dffb6627a2c4150d405a4600aa1ad8a40182a94fe5f903cafd3c0a2f5132814debd0e3bfd61f835
   languageName: node
   linkType: hard
 
@@ -4693,6 +4813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"long@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -5488,6 +5615,46 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10c0/59ece7ca2fb9838031d73a48d4becb9a7cc1ed10e610517c7d8f19a1e02fa47f7c27d557d8a5702bec3cfeccddc853579832b43f449e54635803f277b1c78077
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.2.5":
+  version: 7.5.4
+  resolution: "protobufjs@npm:7.5.4"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "protobufjs@npm:8.0.0"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/6fb29ca3c6abc2095a777407750f6094448b7b68bbf04147ec49ee442f85f151592338449f56d19883ea67c39ce915e3d47ec6c5c92f0bcac1eaba1841ab84ff
   languageName: node
   linkType: hard
 
@@ -6411,7 +6578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.5.0, tslib@npm:^2.8.1":
+"tslib@npm:^2, tslib@npm:^2.5.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -6566,6 +6733,13 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     which-boxed-primitive: "npm:^1.1.1"
   checksum: 10c0/7dbd35ab02b0e05fe07136c72cb9355091242455473ec15057c11430129bab38b7b3624019b8778d02a881c13de44d63cd02d122ee782fb519e1de7775b5b982
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/crc@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@foxglove/crc@npm:0.0.3"
+  checksum: 10c0/887ef5a6cc6bc29296ad3766a3d6c798b4cfb121b33565ba5c423d4584cfea90a2bfbe8508bb1f343a93ba7c848f8f63dfd78c7e9567c17407645bb2282b88da
+  languageName: node
+  linkType: hard
+
 "@foxglove/eslint-plugin@npm:2.0.0":
   version: 2.0.0
   resolution: "@foxglove/eslint-plugin@npm:2.0.0"
@@ -477,6 +484,8 @@ __metadata:
   resolution: "@foxglove/ulog@workspace:."
   dependencies:
     "@foxglove/eslint-plugin": "npm:2.0.0"
+    "@mcap/core": "npm:^2.1.7"
+    "@mcap/nodejs": "npm:^1.0.2"
     "@types/jest": "npm:29.5.14"
     eslint: "npm:9.26.0"
     eslint-config-prettier: "npm:8.10.0"
@@ -832,6 +841,26 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
+  languageName: node
+  linkType: hard
+
+"@mcap/core@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "@mcap/core@npm:2.1.7"
+  dependencies:
+    "@foxglove/crc": "npm:^0.0.3"
+    heap-js: "npm:^2.2.0"
+    tslib: "npm:^2.5.0"
+  checksum: 10c0/61392bc3ae892422bdfda6d38973795ff107275a003feaa8728de6e76fb43ab4ea007480f6a689658043a5611f14a3955e53be880e8de8f2fbbdebf1e589c733
+  languageName: node
+  linkType: hard
+
+"@mcap/nodejs@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@mcap/nodejs@npm:1.0.2"
+  dependencies:
+    tslib: "npm:^2.5.0"
+  checksum: 10c0/add51b689d9acaef7678a4e3802ce7d8481aa233e25d97643ecc4b4307c8504d7b2bb67216d8b5d41daad1ae1ab7d7c58b7d286371526ec4d6759383834f23b7
   languageName: node
   linkType: hard
 
@@ -3358,6 +3387,13 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"heap-js@npm:^2.2.0":
+  version: 2.7.1
+  resolution: "heap-js@npm:2.7.1"
+  checksum: 10c0/a1e4ec7624487f198158599a04b73f5e72f3e805b2ee7dc18ae5340be035a8e5c9e6ee01d8ed4eb81a8bcb6c03b0342f57af386b2552825777a1d7c64adedbd4
   languageName: node
   linkType: hard
 
@@ -6375,7 +6411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.8.1":
+"tslib@npm:^2.5.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
### Changelog
Adds a function called `convertULogFileToMCAP`, which takes a ULog reader and an MCAP writer and writes all ULog data messages to a new MCAP file.

### Docs
None

### Description
`convertULogFileToMCAP` takes a ULog file and produces a new MCAP file containing all data messages, one MCAP channel per ULog subscription.

#### Usage Example
```typescript
import { ULog, convertULogFileToMCAP } from "@foxglove/ulog";
import { FileReader } from "@foxglove/ulog/node";
import { FileHandleWritable } from "@mcap/nodejs";
import { open } from "fs/promises";

export async function main(): Promise<void> {
  const inputFileHandle = new FileReader("path/to/input.ulg");

  const outputFileHandle = await open("path/to/output.mcap", "w");
  const fileHandleWritable = new FileHandleWritable(outputFileHandle);
  const mcapWriter = new McapWriter({
    writable: fileHandleWritable,
    useStatistics: true,
    useChunks: true,
    useChunkIndex: true,
  });
  await convertULogFileToMCAP(
    new ULog(inputFileHandle),
    mcapWriter,
    BigInt(Date.now()) * 1_000n,
  );
}

void main();
```
