### PR TITLE
Enable NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
         with:
           lfs: true
       - run: corepack enable
-      - uses: actions/setup-node@v4.1.0
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: yarn
@@ -35,7 +36,4 @@ jobs:
       - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
-        run: npm publish package.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npx npm@latest publish package.tgz --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
-      - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@11.7.0 publish package.tgz --provenance --access public
+        run: yarn npm publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@latest publish package.tgz --provenance --access public
+        run: npx npm@11.7.0 publish package.tgz --provenance --access public

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/ulog.git"
+    "url": "git+https://github.com/foxglove/ulog.git"
   },
   "author": {
     "name": "Foxglove Technologies Inc",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "typescript": "5.8.3",
     "typescript-eslint": "8.32.0"
   },
-  "packageManager": "yarn@4.5.1"
+  "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6513,11 +6513,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=cef18b"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
+  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Update npm publish workflow to use OIDC trusted publishing with provenance.

## Changes
- Add `id-token: write` and `contents: read` permissions for OIDC authentication
- Use `yarn npm publish` with `--provenance` flag for supply chain security
- Remove `yarn pack` step (no longer needed with direct yarn publishing)
- Update actions to v6
- Remove `NODE_AUTH_TOKEN` secret (no longer needed with OIDC)

## Status
✅ Trusted publishing has been configured on npmjs.com for this package.