### PR TITLE
Fix bug where `parseMessage` skipped padding fields without advancing offset

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -43,10 +43,9 @@ export function parseMessage(
   const output: FieldStruct = {};
   let curOffset = offset;
   for (const field of definition.fields) {
-    if (field.name.startsWith("_")) {
-      continue;
+    if (!field.name.startsWith("_")) {
+      output[field.name] = parseFieldValue(field, definitions, view, curOffset);
     }
-    output[field.name] = parseFieldValue(field, definitions, view, curOffset);
     curOffset += fieldSize(field, definitions) * (field.arrayLength ?? 1);
   }
   if (typeof output.timestamp !== "bigint") {
@@ -108,7 +107,10 @@ export function messageSize(
   definition: MessageDefinition,
   definitions: Map<string, MessageDefinition>,
 ): number {
-  return definition.fields.reduce((size, f) => size + fieldSize(f, definitions), 0);
+  return definition.fields.reduce(
+    (size, f) => size + fieldSize(f, definitions) * (f.arrayLength ?? 1),
+    0,
+  );
 }
 
 export function fieldSize(field: Field, definitions: Map<string, MessageDefinition>): number {


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
- Fixed incorrect parsing of messages containing nested structs with padding or array fields, which caused corrupted/garbage values when reading fields like `position_setpoint_triplet`

### Docs

<!-- Link to a PR or Linear ticket tracking documentation. Write "None" if no documentation changes are needed. -->
None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

I noticed I got garbage values when parsing e.g.

```
position_setpoint_triplet:uint64_t timestamp;position_setpoint previous;position_setpoint current;position_setpoint next;

position_setpoint:uint64_t timestamp;double lat;double lon;float vx;float vy;float vz;float alt;float yaw;float loiter_radius;float loiter_minor_radius;float loiter_orientation;float acceptance_radius;float alt_acceptance_radius;float cruising_speed;float cruising_throttle;bool valid;uint8_t type;bool loiter_direction_counter_clockwise;uint8_t loiter_pattern;bool gliding_enabled;uint8_t[3] _padding0;
```

After some digging, it appears two bugs in `parseMessage` and `messageSize` cause nested struct fields to be read from wrong byte offsets, producing silently corrupted data.

1. `parseMessage` skips padding fields without advancing the byte offset. `curOffset` never advances past the padding bytes. Any field after padding within a struct (or any subsequent nested struct in the parent) starts reading from the wrong position.

2. `messageSize` doesn't multiply by `arrayLength`. `fieldSize` returns the element size (e.g. 1 for `uint8_t`), but `messageSize` sums these without multiplying by array length. So `uint8_t[3] _padding0` contributes 1 byte to the struct size instead of 3. Since `messageSize` is used to compute the stride when laying out nested structs in a parent message, every subsequent field starts at a wrong offset.

For `position_setpoint_triplet`, which contains three consecutive `position_setpoint` structs each with 3 bytes of trailing padding, the `current` field is read 2 bytes early and `next` is read 4 bytes early. The result is that fields return garbage values. There is no error or warning, the data just silently comes out wrong.

**What changed**

`parseMessage`: the offset advancement (`curOffset += ...`) was moved outside the `_` name check so it executes for every field, while the actual value assignment remains guarded.

`messageSize`: the reduce callback now multiplies each field's size by its `arrayLength`, matching what `parseMessage` already does.

