### PR TITLE
Bump version from 2.3.1 to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ulog",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "PX4 ULog file reader",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
- Fix bug where parseMessage skipped padding fields without advancing offset (#20)