### PR TITLE
Sentry error filtering

### DIFF
--- a/src/ChunkedReader.ts
+++ b/src/ChunkedReader.ts
@@ -1,3 +1,4 @@
+import { ULogError } from "./ULogError";
 import { Filelike } from "./file";
 
 const CHUNK_SIZE = 256 * 1024;
@@ -54,7 +55,7 @@ export class ChunkedReader {
   seek(relativeByteOffset: number): void {
     const byteOffset = this.position() + relativeByteOffset;
     if (byteOffset < 0 || byteOffset > this.size()) {
-      throw new Error(`Cannot seek to ${byteOffset}`);
+      throw new ULogError(`Cannot seek to ${byteOffset}`);
     }
 
     // If we have a chunk it is more performant to attempt re-using the chunk. So we try to figure
@@ -76,7 +77,7 @@ export class ChunkedReader {
 
   seekTo(byteOffset: number): void {
     if (byteOffset < 0 || byteOffset > this.size()) {
-      throw new Error(`Cannot seek to ${byteOffset}`);
+      throw new ULogError(`Cannot seek to ${byteOffset}`);
     }
 
     // If we have a chunk it is more performant to attempt re-using the chunk. So we try to figure
@@ -99,7 +100,7 @@ export class ChunkedReader {
   async skip(count: number): Promise<void> {
     const byteOffset = this.#chunkCursor + count;
     if (count < 0 || byteOffset < 0 || byteOffset > this.size()) {
-      throw new Error(`Cannot skip ${count} bytes`);
+      throw new ULogError(`Cannot skip ${count} bytes`);
     }
 
     await this.#fetch(count);
@@ -193,7 +194,7 @@ export class ChunkedReader {
 
   async #fetch(bytesRequired: number): Promise<DataView> {
     if (bytesRequired > this.remaining()) {
-      throw new Error(
+      throw new ULogError(
         `Cannot read ${bytesRequired} bytes from ${this.size()} byte source, ${this.remaining()} bytes remaining`,
       );
     }
@@ -226,7 +227,9 @@ export class ChunkedReader {
       bytesAvailable = this.#chunk.byteLength - this.#chunkCursor;
 
       if (bytesAvailable < bytesRequired) {
-        throw new Error(`Requested ${bytesRequired} bytes but ${bytesAvailable} bytes available`);
+        throw new ULogError(
+          `Requested ${bytesRequired} bytes but ${bytesAvailable} bytes available`,
+        );
       }
     }
 

--- a/src/ULog.ts
+++ b/src/ULog.ts
@@ -1,4 +1,5 @@
 import { ChunkedReader } from "./ChunkedReader";
+import { ULogError } from "./ULogError";
 import {
   Field,
   MessageDefinition,
@@ -96,7 +97,7 @@ export class ULog {
     const data = await reader.readBytes(8);
     for (let i = 0; i < MAGIC.length; i++) {
       if (data[i] !== MAGIC[i]) {
-        throw new Error(`Invalid ULog header: ${toHex(data)}`);
+        throw new ULogError(`Invalid ULog header: ${toHex(data)}`);
       }
     }
 
@@ -152,7 +153,7 @@ export class ULog {
           if (msgdef) {
             definitions.set(msgdef.name, msgdef);
           } else {
-            throw new Error(`oops: ${formatMsg.format}`);
+            throw new ULogError(`oops: ${formatMsg.format}`);
           }
           break;
         }
@@ -189,7 +190,7 @@ export class ULog {
         case MessageType.Synchronization:
         case MessageType.Dropout:
         default:
-          throw new Error(`Unrecognized message type ${message.type}`);
+          throw new ULogError(`Unrecognized message type ${message.type}`);
       }
     }
 
@@ -368,7 +369,7 @@ export class ULog {
           const definition = this.#subscriptions.get(dataMsg.msgId);
           if (!definition) {
             const msgPos = reader.position() - header.size - 3;
-            throw new Error(
+            throw new ULogError(
               `Unknown msg_id ${dataMsg.msgId} for ${header.size} byte 'D' message at offset ${msgPos}`,
             );
           }
@@ -426,7 +427,7 @@ export class ULog {
     const definition = this.#subscriptions.get(dataMsg.msgId);
     if (!definition) {
       const msgPos = reader.position() - rawMessage.size - 3;
-      throw new Error(
+      throw new ULogError(
         `Unknown msg_id ${dataMsg.msgId} for ${rawMessage.size} byte 'D' message at offset ${msgPos}`,
       );
     }
@@ -451,7 +452,7 @@ export class ULog {
   #handleSubscription(subscribe: MessageAddLogged): void {
     const definition = this.#header?.definitions.get(subscribe.messageName);
     if (!definition) {
-      throw new Error(`AddLogged unknown message_name: ${subscribe.messageName}`);
+      throw new ULogError(`AddLogged unknown message_name: ${subscribe.messageName}`);
     }
     this.#subscriptions.set(subscribe.msgId, { ...definition, multiId: subscribe.multiId });
   }
@@ -514,7 +515,7 @@ export function computeTimetampOffset(
     }
     if (field.name === "timestamp") {
       if (field.type !== "uint64_t") {
-        throw new Error(
+        throw new ULogError(
           `Message "${definition.name}" has a timestamp field with a non-uint64_t type`,
         );
       }
@@ -524,5 +525,5 @@ export function computeTimetampOffset(
     curOffset += fieldSize(field, definitions) * (field.arrayLength ?? 1);
   }
 
-  throw new Error(`Message "${definition.name}" is missing a timestamp field`);
+  throw new ULogError(`Message "${definition.name}" is missing a timestamp field`);
 }

--- a/src/ULogError.test.ts
+++ b/src/ULogError.test.ts
@@ -1,0 +1,39 @@
+import { ULogError } from "./ULogError";
+
+describe("ULogError", () => {
+  it("has name 'ULogError'", () => {
+    const error = new ULogError("test message");
+    expect(error.name).toBe("ULogError");
+    expect(error.message).toBe("test message");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ULogError);
+  });
+
+  it("supports cause option", () => {
+    const cause = new Error("underlying issue");
+    const error = new ULogError("wrapper", { cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  describe("is()", () => {
+    it("returns true for ULogError instances", () => {
+      expect(ULogError.is(new ULogError("test"))).toBe(true);
+    });
+
+    it("returns true for Error with name 'ULogError' (cross-worker boundary)", () => {
+      const error = new Error("deserialized");
+      error.name = "ULogError";
+      expect(ULogError.is(error)).toBe(true);
+    });
+
+    it("returns false for regular Error", () => {
+      expect(ULogError.is(new Error("nope"))).toBe(false);
+    });
+
+    it("returns false for non-Error values", () => {
+      expect(ULogError.is("string")).toBe(false);
+      expect(ULogError.is(null)).toBe(false);
+      expect(ULogError.is(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/ULogError.ts
+++ b/src/ULogError.ts
@@ -1,0 +1,25 @@
+/**
+ * Error thrown when a ULog file is malformed or corrupt.
+ *
+ * This error class signals that the error is caused by invalid user data (a bad
+ * recording) rather than a bug in the code. Consumers can check for this error
+ * type to avoid reporting data-quality issues to error-tracking services.
+ *
+ * The `name` property is set to "ULogError" which is preserved by comlink's
+ * error serialization across worker boundaries. Use the static `is()` method
+ * to check for this error type regardless of context.
+ */
+export class ULogError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ULogError";
+  }
+
+  /**
+   * Check whether an error is a ULogError. Works both in the same JS context
+   * (`instanceof`) and across worker boundaries where only `name` survives.
+   */
+  static is(error: unknown): boolean {
+    return error instanceof ULogError || (error instanceof Error && error.name === "ULogError");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./file";
 export * from "./messages";
 export * from "./parse";
 export * from "./ULog";
+export * from "./ULogError";

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,3 +1,4 @@
+import { ULogError } from "./ULogError";
 import { Field, MessageDefinition } from "./definition";
 import { BuiltinType } from "./enums";
 import { FieldPrimitive, FieldStruct, FieldValue, ParsedMessage } from "./messages";
@@ -49,7 +50,7 @@ export function parseMessage(
     curOffset += fieldSize(field, definitions) * (field.arrayLength ?? 1);
   }
   if (typeof output.timestamp !== "bigint") {
-    throw new Error(`Message "${definition.name}" is missing a timestamp field`);
+    throw new ULogError(`Message "${definition.name}" is missing a timestamp field`);
   }
   return output as ParsedMessage;
 }
@@ -63,7 +64,7 @@ export function parseFieldValue(
   if (field.isComplex) {
     const definition = definitions.get(field.type);
     if (!definition) {
-      throw new Error(`Unknown type ${field.type}, searched ${definitions.size} definitions`);
+      throw new ULogError(`Unknown type ${field.type}, searched ${definitions.size} definitions`);
     }
     if (field.arrayLength != undefined) {
       const size = fieldSize(field, definitions);
@@ -121,7 +122,7 @@ export function fieldSize(field: Field, definitions: Map<string, MessageDefiniti
   if (field.isComplex) {
     const definition = definitions.get(field.type);
     if (!definition) {
-      throw new Error(`Unknown type ${field.type}, searched ${definitions.size} definitions`);
+      throw new ULogError(`Unknown type ${field.type}, searched ${definitions.size} definitions`);
     }
     field.size = messageSize(definition, definitions);
   } else {

--- a/src/readMessage.ts
+++ b/src/readMessage.ts
@@ -1,4 +1,5 @@
 import { ChunkedReader } from "./ChunkedReader";
+import { ULogError } from "./ULogError";
 import { LogLevel, MessageType, ParameterDefaultFlags } from "./enums";
 import { toHex } from "./hex";
 import {
@@ -87,7 +88,7 @@ export async function readMessageFlagBits(
   header: MessageHeader,
 ): Promise<MessageFlagBits> {
   if (header.size < 40) {
-    throw new Error(`Invalid 'B' message, expected 40 bytes but got ${header.size}`);
+    throw new ULogError(`Invalid 'B' message, expected 40 bytes but got ${header.size}`);
   }
 
   const compatFlags = await reader.readBytes(8);
@@ -95,7 +96,7 @@ export async function readMessageFlagBits(
 
   for (let i = 0; i < 8; i++) {
     if ((i === 0 && incompatFlags[i]! > 1) || (i !== 0 && incompatFlags[i] !== 0)) {
-      throw new Error(`Incompatible flag bit: ${i} is ${incompatFlags[i]!}`);
+      throw new ULogError(`Incompatible flag bit: ${i} is ${incompatFlags[i]!}`);
     }
   }
 
@@ -118,7 +119,7 @@ export async function readMessageInformation(
 ): Promise<MessageInformation> {
   const keyLen = await reader.readUint8();
   if (keyLen > header.size - 1) {
-    throw new Error(`Invalid 'I' message, size is ${header.size} but key_len is ${keyLen}`);
+    throw new ULogError(`Invalid 'I' message, size is ${header.size} but key_len is ${keyLen}`);
   }
 
   return {
@@ -136,7 +137,7 @@ export async function readMessageInformationMulti(
   const isContinued = Boolean(await reader.readUint8());
   const keyLen = await reader.readUint8();
   if (keyLen > header.size - 1) {
-    throw new Error(`Invalid 'I' message, size is ${header.size} but key_len is ${keyLen}`);
+    throw new ULogError(`Invalid 'I' message, size is ${header.size} but key_len is ${keyLen}`);
   }
 
   const key = await reader.readString(keyLen);
@@ -158,7 +159,7 @@ export async function readMessageParameter(
 ): Promise<MessageParameter> {
   const keyLen = await reader.readUint8();
   if (keyLen > header.size - 1) {
-    throw new Error(`Invalid 'P' message, size is ${header.size} but key_len is ${keyLen}`);
+    throw new ULogError(`Invalid 'P' message, size is ${header.size} but key_len is ${keyLen}`);
   }
 
   const key = await reader.readString(keyLen);
@@ -173,7 +174,7 @@ export async function readMessageParameterDefault(
   const defaultTypes = (await reader.readUint8()) as ParameterDefaultFlags;
   const keyLen = await reader.readUint8();
   if (keyLen > header.size - 2) {
-    throw new Error(`Invalid 'Q' message, size is ${header.size} but key_len is ${keyLen}`);
+    throw new ULogError(`Invalid 'Q' message, size is ${header.size} but key_len is ${keyLen}`);
   }
 
   const key = await reader.readString(keyLen);
@@ -186,7 +187,7 @@ export async function readMessageAddLogged(
   header: MessageHeader,
 ): Promise<MessageAddLogged> {
   if (header.size < 3) {
-    throw new Error(`Invalid 'A' message, size is ${header.size} but expected at least 3`);
+    throw new ULogError(`Invalid 'A' message, size is ${header.size} but expected at least 3`);
   }
 
   const multiId = await reader.readUint8();
@@ -200,7 +201,7 @@ export async function readMessageRemoveLogged(
   header: MessageHeader,
 ): Promise<MessageRemoveLogged> {
   if (header.size < 1) {
-    throw new Error(`Invalid 'R' message, size is ${header.size} but expected at least 1`);
+    throw new ULogError(`Invalid 'R' message, size is ${header.size} but expected at least 1`);
   }
 
   const msgId = await reader.readUint8();
@@ -212,7 +213,7 @@ export async function readMessageData(
   header: MessageHeader,
 ): Promise<MessageData> {
   if (header.size < 2) {
-    throw new Error(`Invalid 'D' message, size is ${header.size} but expected at least 2`);
+    throw new ULogError(`Invalid 'D' message, size is ${header.size} but expected at least 2`);
   }
 
   const msgId = await reader.readUint16();
@@ -225,7 +226,7 @@ export async function readMessageLog(
   header: MessageHeader,
 ): Promise<MessageLog> {
   if (header.size < 9) {
-    throw new Error(`Invalid 'L' message, size is ${header.size} but expected at least 9`);
+    throw new ULogError(`Invalid 'L' message, size is ${header.size} but expected at least 9`);
   }
 
   const logLevel = (await reader.readUint8()) as LogLevel;
@@ -239,7 +240,7 @@ export async function readMessageLogTagged(
   header: MessageHeader,
 ): Promise<MessageLogTagged> {
   if (header.size < 11) {
-    throw new Error(`Invalid 'T' message, size is ${header.size} but expected at least 11`);
+    throw new ULogError(`Invalid 'T' message, size is ${header.size} but expected at least 11`);
   }
 
   const logLevel = (await reader.readUint8()) as LogLevel;
@@ -254,13 +255,13 @@ export async function readMessageSynchronization(
   header: MessageHeader,
 ): Promise<MessageSynchronization> {
   if (header.size !== 8) {
-    throw new Error(`Invalid 'S' message, size is ${header.size} but expected 8`);
+    throw new ULogError(`Invalid 'S' message, size is ${header.size} but expected 8`);
   }
 
   const syncMagic = await reader.readBytes(8);
   for (let i = 0; i < 8; i++) {
     if (syncMagic[i] !== SYNC_MAGIC[i]) {
-      throw new Error(`Invalid 'S' message: ${toHex(syncMagic)}`);
+      throw new ULogError(`Invalid 'S' message: ${toHex(syncMagic)}`);
     }
   }
 
@@ -272,7 +273,7 @@ export async function readMessageDropout(
   header: MessageHeader,
 ): Promise<MessageDropout> {
   if (header.size < 2) {
-    throw new Error(`Invalid 'O' message, size is ${header.size} but expected at least 2`);
+    throw new ULogError(`Invalid 'O' message, size is ${header.size} but expected at least 2`);
   }
 
   const duration = await reader.readUint16();


### PR DESCRIPTION
Introduce `ULogError` to differentiate between invalid ULog file errors and programming errors.

This allows consuming applications to filter out user-data-related errors (e.g., corrupt recordings) from Sentry reporting, focusing on actual code bugs. The `ULogError.name` property is preserved across Comlink worker boundaries, enabling this distinction.

---
<p><a href="https://cursor.com/agents?id=bc-4c660c9c-3e04-4bc2-bb74-d12e55b81ab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c660c9c-3e04-4bc2-bb74-d12e55b81ab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

